### PR TITLE
Add `Tux.set_velocity()` to scripting api.

### DIFF
--- a/src/scripting/player.cpp
+++ b/src/scripting/player.cpp
@@ -203,6 +203,13 @@ Player::get_velocity_y() const
   return object.get_physic().get_velocity_y();
 }
 
+void 
+Player::set_velocity(float x, float y)
+{
+  SCRIPT_GUARD_VOID;
+  object.get_physic().set_velocity(x, y);
+}
+
 bool
 Player::has_grabbed(const std::string& name) const
 {

--- a/src/scripting/player.hpp
+++ b/src/scripting/player.hpp
@@ -193,6 +193,9 @@ public:
    */
   float get_velocity_y() const;
 
+  /**
+   * Sets the velocity of the player to a programmable/variable speed.
+   */
   void set_velocity(float x, float y);
 
   /**

--- a/src/scripting/player.hpp
+++ b/src/scripting/player.hpp
@@ -193,6 +193,8 @@ public:
    */
   float get_velocity_y() const;
 
+  void set_velocity(float x, float y);
+
   /**
    * Gets the X coordinate of the player.
    */

--- a/src/scripting/wrapper.cpp
+++ b/src/scripting/wrapper.cpp
@@ -7242,6 +7242,41 @@ static SQInteger Player_get_velocity_y_wrapper(HSQUIRRELVM vm)
 
 }
 
+static SQInteger Player_set_velocity_wrapper(HSQUIRRELVM vm)
+{
+  SQUserPointer data;
+  if(SQ_FAILED(sq_getinstanceup(vm, 1, &data, nullptr, SQTrue)) || !data) {
+    sq_throwerror(vm, _SC("'set_velocity' called without instance"));
+    return SQ_ERROR;
+  }
+  scripting::Player* _this = reinterpret_cast<scripting::Player*> (data);
+
+  SQFloat arg0;
+  if(SQ_FAILED(sq_getfloat(vm, 2, &arg0))) {
+    sq_throwerror(vm, _SC("Argument 1 not a float"));
+    return SQ_ERROR;
+  }
+  SQFloat arg1;
+  if(SQ_FAILED(sq_getfloat(vm, 3, &arg1))) {
+    sq_throwerror(vm, _SC("Argument 2 not a float"));
+    return SQ_ERROR;
+  }
+
+  try {
+    _this->set_velocity(arg0, arg1);
+
+    return 0;
+
+  } catch(std::exception& e) {
+    sq_throwerror(vm, e.what());
+    return SQ_ERROR;
+  } catch(...) {
+    sq_throwerror(vm, _SC("Unexpected exception while executing function 'set_velocity'"));
+    return SQ_ERROR;
+  }
+
+}
+
 static SQInteger Player_get_x_wrapper(HSQUIRRELVM vm)
 {
   SQUserPointer data;
@@ -15244,6 +15279,13 @@ void register_supertux_wrapper(HSQUIRRELVM v)
   sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".");
   if(SQ_FAILED(sq_createslot(v, -3))) {
     throw SquirrelError(v, "Couldn't register function 'get_velocity_y'");
+  }
+
+  sq_pushstring(v, "set_velocity", -1);
+  sq_newclosure(v, &Player_set_velocity_wrapper, 0);
+  sq_setparamscheck(v, SQ_MATCHTYPEMASKSTRING, ".b|nb|n");
+  if(SQ_FAILED(sq_createslot(v, -3))) {
+    throw SquirrelError(v, "Couldn't register function 'set_velocity'");
   }
 
   sq_pushstring(v, "get_x", -1);


### PR DESCRIPTION
Pretty self explanatory.

We have `Tux.get_velocity_x()` and `Tux.get_velocity_y()` so why not add a velocity setter as well?